### PR TITLE
Prevent NextJS from exiting on fatal error

### DIFF
--- a/qms/frontend/sentry.server.config.js
+++ b/qms/frontend/sentry.server.config.js
@@ -8,5 +8,8 @@ if (process.env.SENTRY_SERVER_DSN) {
     // `release` value here - use the environment variable `SENTRY_RELEASE`, so
     // that it will also get attached to your source maps
     environment: process.env.NEXTJS_ENVIRONMENT,
+    // Without this, sentry forces the shutdown, while the default behaviour does not
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onFatalError() {},
   });
 }


### PR DESCRIPTION
The Sentry handler had a default behavior that any fatal error should exit the program.
The default behavior in NextJS is just to log it and not quit the application.

This PR overwrites the default Sentry functionality, therefore letting NextJS handle it instead.